### PR TITLE
be compatible with new and old hashdiff gem

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'chef@parchment.com'
 license          'MIT License, see LICENSE file'
 description      'Configures Vault resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'
 
 supports      'ubuntu'
 chef_version  '>= 12'

--- a/resources/vault_policies.rb
+++ b/resources/vault_policies.rb
@@ -25,7 +25,11 @@ load_current_value do |policies_resource|
   end.reduce({}, :merge)
 
   # Find differences between passed in policies and policies already configure in vault
-  policy_diff = HashDiff.diff(current_policies, policies_resource.policies, array_path: true)
+  policy_diff = begin
+                  Hashdiff.diff(current_policies, policies_resource.policies, array_path: true)
+                rescue NameError
+                  HashDiff.diff(current_policies, policies_resource.policies, array_path: true)
+                end
   subtractions = policy_diff.map { |a| a[1][0] if ['-'].include? a[0] }.compact.uniq
   # We don't want the removed policies to show in configure action
   # Let remove stale logic deal with them

--- a/test/cookbooks/reference_implementation/Berksfile.lock
+++ b/test/cookbooks/reference_implementation/Berksfile.lock
@@ -10,4 +10,4 @@ GRAPH
   reference_implementation (0.0.0)
     docker (>= 0.0.0)
     vault_resources (>= 0.0.0)
-  vault_resources (0.1.0)
+  vault_resources (0.1.1)


### PR DESCRIPTION
if the newer hashdiff gem is installed (>=1.0) then a NameError can be
thrown because the name of the class has changed.