### PR TITLE
Fix syntax error in legacy acl call

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'chef@parchment.com'
 license          'MIT License, see LICENSE file'
 description      'Configures Vault resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.2.1'
 
 supports      'ubuntu'
 chef_version  '>= 12'

--- a/resources/vault_secret_engine_consul.rb
+++ b/resources/vault_secret_engine_consul.rb
@@ -39,7 +39,7 @@ action :configure do
         # https://www.consul.io/docs/acl/acl-legacy
         vault.logical.write("consul/roles/#{role}",
                             lease: config['lease'],
-                            policy: Base64.encode64(config['policy'].join("\n")) unless config['policy'].nil?
+                            policy: Base64.encode64(config['policy'].join("\n")), 'force' => true) unless config['policy'].nil?
       end
     end
   end


### PR DESCRIPTION
I updated it after testing only the new acl system and missed this as I didn't repull the cookbook.