### PR TITLE
Handle existing group aliases and changes to them

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'chef@parchment.com'
 license          'MIT License, see LICENSE file'
 description      'Configures Vault resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.3.1'
 
 supports      'ubuntu'
 chef_version  '>= 12'

--- a/test/cookbooks/reference_implementation/Berksfile.lock
+++ b/test/cookbooks/reference_implementation/Berksfile.lock
@@ -10,4 +10,4 @@ GRAPH
   reference_implementation (0.0.0)
     docker (>= 0.0.0)
     vault_resources (>= 0.0.0)
-  vault_resources (0.2.4)
+  vault_resources (0.3.1)

--- a/test/cookbooks/reference_implementation/recipes/default.rb
+++ b/test/cookbooks/reference_implementation/recipes/default.rb
@@ -108,7 +108,7 @@ vault_authentication_oidc 'configure oidc' do
   oidc_groups node['reference_implementation']['oidc']['groups']
   oidc_group_aliases node['reference_implementation']['oidc']['group_aliases']
   remove_oidc_groups node['reference_implementation']['oidc']['remove_groups']
-  action %i[prune configure]
+  action %i[configure]
   sensitive true
 end
 


### PR DESCRIPTION
Was testing with always prune enabled on the groups, so they were being recreated from scratch on every run and I didn't run into the issue of existing group aliases.   We should be able to update groups and group aliases without requiring pruning.